### PR TITLE
release: highlights of v0.0.4

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: istio-workspace
 title: Istio Workspace
-version: latest
+version: v0.0.4
 nav:
   - modules/ROOT/nav.adoc
 

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: istio-workspace
 title: Istio Workspace
-version: v0.0.4
+version: latest
 nav:
   - modules/ROOT/nav.adoc
 

--- a/docs/modules/ROOT/pages/release_notes.adoc
+++ b/docs/modules/ROOT/pages/release_notes.adoc
@@ -1,4 +1,6 @@
 = Releases
+include::release_notes/v0.0.4.adoc[]
+
 
 include::release_notes/v0.0.3.adoc[]
 

--- a/docs/modules/ROOT/pages/release_notes/v0.0.4.adoc
+++ b/docs/modules/ROOT/pages/release_notes/v0.0.4.adoc
@@ -1,3 +1,36 @@
 == Highlights of v0.0.4 release
 
 Testing GH Actions \o/
+
+==== New features
+
+ * feat(test): add gRPC support to Test-Service and Test-Generator (https://github.com/Maistra/istio-workspace/pull/414[#414]), by https://github.com/aslakknutsen[@aslakknutsen]
+ * feat: ability to specify a file name when using get.sh (https://github.com/Maistra/istio-workspace/pull/410[#410]), by https://github.com/bartoszmajsak[@bartoszmajsak]
+ * fix: sets logger based on OPERATOR_NAME env var (https://github.com/Maistra/istio-workspace/pull/403[#403]), by https://github.com/bartoszmajsak[@bartoszmajsak]
+ * docs: improvements identified during the release (https://github.com/Maistra/istio-workspace/pull/400[#400]), by https://github.com/bartoszmajsak[@bartoszmajsak]
+
+==== Bug fixes
+
+ * lint(deprecated): updated packages runtime/scheme and runtime/signals (https://github.com/Maistra/istio-workspace/pull/415[#415]), by https://github.com/aslakknutsen[@aslakknutsen]
+ * docs: fixes headers in release notes (https://github.com/Maistra/istio-workspace/pull/407[#407]), by https://github.com/bartoszmajsak[@bartoszmajsak]
+ * fix(docs): adds extra space between include directives (https://github.com/Maistra/istio-workspace/pull/401[#401]), by https://github.com/bartoszmajsak[@bartoszmajsak]
+
+==== Latest dependencies update
+
+ * chore(deps): to latest (https://github.com/Maistra/istio-workspace/pull/422[#422])
+ * github.com/google/go-github to 31.0.0 (https://github.com/Maistra/istio-workspace/pull/416[#416])
+ * github.com/hashicorp/go-multierror to 1.1.0 (https://github.com/Maistra/istio-workspace/pull/411[#411])
+ * github.com/operator-framework/operator-sdk to 0.17.0 (https://github.com/Maistra/istio-workspace/pull/420[#420])
+ * github.com/spf13/cobra to 1.0.0 (https://github.com/Maistra/istio-workspace/pull/417[#417])
+ * github.com/spf13/viper to 1.6.3 (https://github.com/Maistra/istio-workspace/pull/419[#419])
+
+==== Project infrastructure
+
+ * feat: ability to specify a file name when using get.sh (https://github.com/Maistra/istio-workspace/pull/410[#410]), by https://github.com/bartoszmajsak[@bartoszmajsak]
+ * chore(ci): bumps golang to 1.14.1 (https://github.com/Maistra/istio-workspace/pull/408[#408]), by https://github.com/bartoszmajsak[@bartoszmajsak]
+
+==== Testing
+
+ * feat(test): add gRPC support to Test-Service and Test-Generator (https://github.com/Maistra/istio-workspace/pull/414[#414]), by https://github.com/aslakknutsen[@aslakknutsen]
+
+

--- a/docs/modules/ROOT/pages/release_notes/v0.0.4.adoc
+++ b/docs/modules/ROOT/pages/release_notes/v0.0.4.adoc
@@ -1,0 +1,3 @@
+== Highlights of v0.0.4 release
+
+Testing GH Actions \o/


### PR DESCRIPTION
##### Release automation driven by Pull Request

By creating a [Pull Request](https://github.com/bartoszmajsak/istio-workspace/pull/30) with release notes we can automate the release process simply by using two commands in the comments.

##### Changelog generation using `/release` command

An owner, committer, or a member of our organization can use `/release` command to trigger changelog generation. `/release` command takes a version as an argument that needs to conform [semantic versioning](https://semver.org/). For example, commenting `/release v0.0.4` will trigger changelog generation for version `v0.0.4`. 

Such a comment results in adding commits to created PR which consists of:

- changelog based on all PRs since the last release, which will be appended to release highlights submitted as part of this PR
- setting "version commit" which consist of documentation version lock to `v0.0.4`
- commit which reverts documentation version lock back to `latest`

Changelog generation job performs validation and will fail if one of the issues listed below occurs:

- `version` parameter does not conform with [semantic versioning](https://semver.org/)
- `version` has been already released
- release notes do not exist (submitting this file is the only thing needed for this [PR](https://github.com/bartoszmajsak/istio-workspace/pull/30))
- any of the PRs created since the last release have no labels

In all the cases above PR will have `release / changelog` status set to failure and comment with an appropriate error message will be added by the bot. You can see that in the [comments](https://github.com/bartoszmajsak/istio-workspace/pull/30).

##### Triggering release process by invoking `/shipit`

Once changelog generation succeeds we can trigger the actual release process. This can be done by commenting with `/shipit` command without any parameters.

This will result in rebasing this PR on top of the target branch if all the required checks have been successful. Once "release commit" appears on the target branch it will be automatically tagged based on `/tag VERSION` comment in its message. That tag would trigger the actual release process of generating binaries and documentation from the tagged commit.

**Comments below demonstrate the flow and potential corner cases**.

